### PR TITLE
Add support for mixpanel People API `set` and `increment` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+/target

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,7 @@
                  [org.clojure/data.json "0.1.2"]
                  [commons-codec/commons-codec "1.6"]
                  [org.clojure/tools.logging "0.2.3"]]
-  :dev-dependencies [[org.slf4j/slf4j-simple "1.6.4"]])
+  :profiles {:dev {:dependencies [[midje "1.4.0"]
+                                  [org.slf4j/slf4j-simple "1.6.4"]]}}
+  :plugins [[lein-midje "2.0.0-SNAPSHOT"]]
+  :min-lein-version "2.0.0")

--- a/test/clj_mixpanel/test/core.clj
+++ b/test/clj_mixpanel/test/core.clj
@@ -1,6 +1,35 @@
 (ns clj-mixpanel.test.core
+  (:refer-clojure :exclude [set])
   (:use [clj-mixpanel.core])
-  (:use [clojure.test]))
+  (:use [midje.sweet]))
 
-(deftest replace-me ;; FIXME: write
-  (is false "No tests have been written."))
+(let [response {:status 200 :body "hi"}
+      token "123"
+      distinct-id "456"
+      event "login"
+      timestamp "12345"]
+
+  (fact (track token event {:distinct-id distinct-id :timestamp timestamp}) => response
+    (provided
+      (post track-url
+       {:data {:event event
+               :properties {:token token :distinct_id distinct-id :time timestamp}}
+        :ip "1" :test "0"})
+      => response))
+
+  (fact (set token distinct-id {:hams :clams}) => response
+    (provided
+      (post engage-url
+            {:data {:$token token
+                    :$distinct_id distinct-id
+                    :$set {:hams :clams}}})
+      => response))
+
+  (fact (increment token distinct-id {:hams :clams}) => response
+    (provided
+      (post engage-url
+            {:data {:$token token
+                    :$distinct_id distinct-id
+                    :$add {:hams :clams}}})
+      => response)))
+


### PR DESCRIPTION
Also:
- deprecate `notify` in favor of `track` for parity with the mixpanel
  JavaScript API. `track` and the new functions no longer return a
  future, letting the client add this overhead if desired
- introduce midje and some basic facts
- upgrade project.clj to lein 2
