### PR TITLE
Add basic support for getting data out of Mixpanel

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,42 @@ Note that `notify` wraps sending notifications as a [http://clojuredocs.org/cloj
 
 The response can be retrieved by dereferencing the result. In the event of an error, the API will return a 200 response with more details in the body.
 
+### Data export
+
+Mixpanel has two slightly different export APIs - one for getting raw
+event data and one for "formatted data" that gives you programmatic
+access to many of the metrics you can see in the Mixpanel UI.
+
+`clj-mixpanel` has basic support for both:
+
+Raw data access:
+```clj
+(->>
+ (export {:api-key "yourkeyhere
+          :api-secret "yoursecrethere
+         {:event (json-str ["Your Event Name"])
+          :from_date "2014-08-14"
+          :to_date "2014-08-17"})
+ :body
+ s/split-lines
+ (map read-json)
+ first)
+=> {:event "Your Event Name", :properties {:$region "California", :$initial_referring_domain "$direct", :existing_user true, :$initial_referrer "$direct", :mp_country_code "US", :$screen_height 1200, :$city "Mountain View", :$os "Mac OS X", :distinct_id "xxxxxxxx", :$screen_width 1920, :$browser "Chrome"}}
+```
+
+Formatted data access:
+```clj
+(-> (get {:api-key "yourkeyhere"
+          :api-secret "yoursecrethere"}
+         "events" {:event (json-str ["Your Event Name"])
+                   :type "unique"
+                   :unit "week"
+                   :interval 2})
+    :body
+    read-json)
+=> {:legend_size 1, :data {:series ["2014-08-11" "2014-08-18"], :values {:"Your Event Name" {:2014-08-18 2754, :2014-08-11 4136, :2014-08-04 4101}}}}
+```
+
 ## License
 
 Copyright &copy; 2012 Paul Ingles

--- a/src/clj_mixpanel/data.clj
+++ b/src/clj_mixpanel/data.clj
@@ -1,0 +1,47 @@
+(ns clj-mixpanel.data
+  (:import [org.apache.commons.codec.digest DigestUtils]
+           [java.util Date UUID])
+  (:require [clj-http.client :as http]
+            [clojure.string :as s]
+            [clojure.data.json :refer [json-str read-json]])
+  (:refer-clojure :exclude [get]))
+
+(def url "http://mixpanel.com/api/2.0/")
+(def export-url "http://data.mixpanel.com/api/2.0/export")
+
+(defn- now
+  []
+  (/ (.getTime (Date. )) 1000))
+
+;; request signing
+
+(defn- sort-args [args]
+  (sort-by #(name (first %)) args))
+
+(defn- concat-args [args]
+  (s/join (map (fn [[k v]] (str (name k) "=" v)) args)))
+
+(defn- signature-from-args-and-secret [args secret]
+  (DigestUtils/md5Hex (str (-> args sort-args concat-args) secret)))
+
+(defn sign [params secret]
+  (let [{:keys [api_key expire]} params
+        signature (signature-from-args-and-secret params secret)]
+    (merge params {:sig signature})))
+
+(defn sign-params [params key secret duration]
+  (-> params
+      (merge {:api_key key
+              :expire (str (int (+ duration (now))))})
+      (sign secret)))
+
+(defn new-client [api-key api-secret options]
+  (merge options {:api-key api-key :api-secret api-secret}))
+
+(defn get [client path params]
+  (http/get (str url path) {:query-params (sign-params params (:api-key client) (:api-secret client) (or (:duration client) 60))}))
+
+;;; specific endpoints
+
+(defn export [client params]
+  (http/get export-url {:query-params (sign-params params (:api-key client) (:api-secret client) (or (:duration client) 3600))}))


### PR DESCRIPTION
Mixpanel has two slightly different export APIs - one for getting raw
event data and one for "formatted data" that gives you programmatic
access to many of the metrics you can see in the Mixpanel UI.

Add basic support for both.
